### PR TITLE
ユーザーマイページと過去の投稿一覧ページのフロント実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,5 +5,6 @@
 @import "modules/toppage";
 @import "modules/newpost";
 @import "modules/showpost";
+@import "mypages/past";
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,5 +6,6 @@
 @import "modules/newpost";
 @import "modules/showpost";
 @import "mypages/past";
+@import "devise/edit";
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/app/assets/stylesheets/devise/_edit.scss
+++ b/app/assets/stylesheets/devise/_edit.scss
@@ -1,0 +1,97 @@
+.user-my-edit{
+  height: 100px;
+  width: 215px;
+  color: white;
+  font-weight: bold;
+  font-size: 40px;
+  font-style: oblique;
+  margin: auto;
+  line-height: 100px;
+  padding-left: 5px;
+}
+.current-pass{
+  height: 30px;
+  width: 196px;
+  color: white;
+  font-size: 20px;
+  font-weight: bold;
+  display: block;
+  margin: auto;
+}
+.current-field{
+  height: 40px;
+  width: 300px;
+  display: block;
+  margin: auto;
+}
+.current-message{
+  height: 30px;
+  width: 635px;
+  color: white;
+  font-size: 20px;
+  font-weight: bold;
+  display: block;
+  margin: auto;
+}
+.pass-message{
+  height: 30px;
+  width: 460px;
+  color: white;
+  font-size: 20px;
+  font-weight: bold;
+  display: block;
+  margin: auto;
+}
+.len-message{
+  height: 30px;
+  width: 145px;
+  color: white;
+  font-size: 13px;
+  display: block;
+  margin: auto;
+}
+h3{
+  height: 100px;
+  width: 100%;
+  font-size: 40px;
+  text-align: center;
+  font-weight: bold;
+  background-color: #000000;
+  display: block;
+  line-height: 130px;
+  font-style: oblique;
+  color: white;
+}
+.un-happy{
+  height: 100px;
+  width: 100%;
+  font-size: 20px;
+  text-align: center;
+  font-weight: bold;
+  background-color: #000000;
+  display: block;
+  color: white;
+  font-style: oblique;
+  .can-ac{
+    height: 30px;
+    width: 200px;
+    background-color: white;
+    margin-top: 10px;
+    font-size: 14px;
+    border: none;
+    cursor: pointer;
+  }
+}
+.current-back{
+  height: 40px;
+  width: 100%;
+  background-color: #000000;
+  padding-bottom: 80px;
+  .back-back{
+    display: block;
+    margin: auto;
+    height: 20px;
+    width: 40px;
+    color: rgb(255, 141, 34);
+  }
+}

--- a/app/assets/stylesheets/modules/_toppage.scss
+++ b/app/assets/stylesheets/modules/_toppage.scss
@@ -29,6 +29,7 @@
       line-height: 40px;
       padding-left: 20px;
       color: white;
+      cursor: pointer;
       .fa-user{
         color: rgb(255, 141, 34);
       }
@@ -59,6 +60,7 @@
       padding-left: 35px;
       color: white;
       font-weight: bold;
+      cursor: pointer;
       .fa-film{
         color: rgb(255, 141, 34);
       }

--- a/app/assets/stylesheets/mypages/_past.scss
+++ b/app/assets/stylesheets/mypages/_past.scss
@@ -1,0 +1,190 @@
+* {
+  box-sizing: border-box;
+}
+
+.past{
+  height: auto;
+  width: 100%;
+  background-color: rgb(170, 170, 170);
+  .past-header{
+    height: 200px;
+    width: 100%;
+    background-color: #000000;
+    padding-top: 50px;
+    .pasttitle{
+      height: 100px;
+      width: 145px;
+      margin: auto;
+      display: block;
+      color: rgb(255, 255, 255);
+      font-weight: bold;
+      font-size: 34px;
+      font-style: oblique;
+      cursor: pointer;
+      text-decoration: none;
+    }
+  }
+  .past-main{
+    height: auto;
+    width: 100%;
+    background-color: rgb(170, 170, 170);
+    padding-top: 40px;
+    padding-bottom: 40px;
+    .past-content{
+      background-color: rgb(255, 255, 255);
+      height: 500px;
+      width: 800px;
+      padding-bottom: 40px;
+      margin: auto;
+      margin-bottom: 30px;
+      .mypost{
+        height: 70px;
+        width: 100%;
+        background-color: rgb(77, 77, 77);
+        color: white;
+        font-size: 25px;
+        font-weight: bold;
+        line-height: 70px;
+        padding-left: 30px;
+        .fa-smile{
+          font-size: 25px;
+          color: rgb(255, 141, 34);
+          margin-right: 10px;
+        }
+      }
+    }
+    .my-top{
+      height: 30px;
+      width: 200px;
+      margin: auto;
+      text-align: center;
+      text-decoration: none;
+      .go-top{
+        color: rgb(255, 141, 34);
+        font-size: 20px;
+        font-weight: bold;
+        cursor: pointer;
+        display: inline-block;
+      }
+    }
+  }
+}
+
+
+.my-p{
+  height: auto;
+  width: 100%;
+  .past-header{
+    height: 200px;
+    width: 100%;
+    background-color: #000000;
+    padding-top: 50px;
+    .pasttitle{
+      height: 100px;
+      width: 145px;
+      margin: auto;
+      display: block;
+      color: rgb(255, 255, 255);
+      font-weight: bold;
+      font-size: 34px;
+      font-style: oblique;
+      cursor: pointer;
+      text-decoration: none;
+    }
+  }
+  .my-content{
+    height: 589px;
+    width: 100%;
+    background-color: rgb(170, 170, 170);
+    padding: 50px;
+    .my-edit{
+      height: 30px;
+      width: 500px;
+      margin: auto;
+      padding-left: 330px;
+      margin-bottom: 5px;
+      .myedit-btn{
+        background-color: rgb(255, 141, 34);
+        border: none;
+        font-weight: bold;
+        color: rgb(255, 255, 255);
+        border-radius: 50px;
+        width: 170px;
+        height: 30px;
+        cursor: pointer;
+      }
+    }
+    .my-details{
+      height: 300px;
+      width: 500px;
+      background-color: rgb(255, 255, 255);
+      margin: auto;
+      margin-bottom: 5px;
+      table{
+        height: 100%;
+        width: 100%;
+        border: rgb(77, 77, 77) solid 3px;
+        th{
+          height: 30px;
+          width: 40%;
+          border: rgb(77, 77, 77) solid 1px;
+          text-align: center;
+          font-weight: bold;
+        }
+        td{
+          height: 30px;
+          width: 60%;
+          border: rgb(77, 77, 77) solid 1px;
+          text-align: center;
+          font-weight: bold;
+        }
+      }
+    }
+    .my-out{
+      height: 30px;
+      width: 500px;
+      margin: auto;
+      padding-left: 330px;
+      margin-bottom: 25px;
+      .mylog-out{
+        background-color: #000000;
+        border: none;
+        font-weight: bold;
+        color: rgb(255, 255, 255);
+        border-radius: 50px;
+        width: 170px;
+        height: 30px;
+        cursor: pointer;
+      }
+    }
+    .mypast{
+      height: 30px;
+      width: 200px;
+      margin: auto;
+      text-align: center;
+      text-decoration: none;
+      margin-bottom: 10px;
+      .go-past{
+        color: rgb(255, 141, 34);
+        font-size: 20px;
+        font-weight: bold;
+        cursor: pointer;
+        display: inline-block;
+      }
+    }
+    .my-top{
+      height: 30px;
+      width: 200px;
+      margin: auto;
+      text-align: center;
+      text-decoration: none;
+      .go-top{
+        color: rgb(255, 141, 34);
+        font-size: 20px;
+        font-weight: bold;
+        cursor: pointer;
+        display: inline-block;
+      }
+    }
+  }
+}

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,0 +1,9 @@
+class MypagesController < ApplicationController
+  
+  def index
+  end
+
+  def show
+  end
+  
+end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,36 +1,44 @@
 %h2
-  Edit #{resource_name.to_s.humanize}
+  .user-my-edit
+    Edit #{resource_name.to_s.humanize}
 = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
   = render "devise/shared/error_messages", resource: resource
   .field
-    = f.label :email
+    = f.label :nickname,class:"nick"
     %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
+    =f.text_field :nickname,class:"nick-field"
+  .field
+    = f.label :email,class:"in-mail"
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email",class:"in-e"
   - if devise_mapping.confirmable? && resource.pending_reconfirmation?
     %div
       Currently waiting confirmation for: #{resource.unconfirmed_email}
   .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
+    = f.label :password,class:"in-pass"
+    %i.pass-message (leave blank if you don't want to change it)
     %br/
-    = f.password_field :password, autocomplete: "new-password"
+    = f.password_field :password, autocomplete: "new-password",class:"in-pas"
     - if @minimum_password_length
       %br/
-      %em
+      %em.len-message
         = @minimum_password_length
         characters minimum
   .field
-    = f.label :password_confirmation
+    = f.label :password_confirmation,class:"conf"
     %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
+    = f.password_field :password_confirmation, autocomplete: "new-password",class:"conf-field"
   .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
+    = f.label :current_password,class:"current-pass"
+    %i.current-message (we need your current password to confirm your changes)
     %br/
-    = f.password_field :current_password, autocomplete: "current-password"
+    = f.password_field :current_password, autocomplete: "current-password",class:"current-field"
   .actions
-    = f.submit "Update"
-%h3 Cancel my account
-%p
-  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+    = f.submit "Update",class:"in-btn"
+  %h3 Cancel my account
+  %p.un-happy
+    Unhappy?
+    %br
+    #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete,class: "can-ac"}
+.current-back
+  = link_to "Back", :back,class:"back-back"

--- a/app/views/mypages/_logo.html.haml
+++ b/app/views/mypages/_logo.html.haml
@@ -1,0 +1,3 @@
+.past-header
+  %label
+    = link_to "MOVIE WORDS",root_path ,class:"pasttitle"

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -1,0 +1,11 @@
+.past
+  = render "logo"
+  .past-main
+    .past-content
+      .mypost
+        %i.fas.fa-smile
+        MY POSTS
+    = link_to "/" do
+      .my-top
+        %label.go-top
+          << TOPへ戻る

--- a/app/views/mypages/show.html.haml
+++ b/app/views/mypages/show.html.haml
@@ -1,0 +1,44 @@
+.my-p
+  = render "logo"
+  .my-content
+    .my-edit
+      = link_to edit_user_registration_path do
+        %button.myedit-btn
+          User情報を編集する
+    .my-details
+      %table
+        %tr
+          %th
+            nick name
+          %td
+            = current_user.nickname
+        %tr
+          %th
+            e-mail
+          %td
+            = current_user.email
+        %tr
+          %th
+            登録日
+          %td
+            = current_user.created_at
+        %tr
+          %th
+            投稿数
+          %td
+            0
+            POST
+        %tr
+          %th
+          %td
+    .my-out
+      %button.mylog-out
+        ログアウト
+    = link_to "/mypages" do
+      .mypast
+        %label.go-past
+          << 過去の投稿を見る
+    = link_to "/" do
+      .my-top
+        %label.go-top
+          << TOPへ戻る

--- a/app/views/posts/_side-bar.html.haml
+++ b/app/views/posts/_side-bar.html.haml
@@ -4,18 +4,20 @@
     %br
     WORDS
   - if user_signed_in?
-    %label.currentusername
-      %i.far.fa-user
-      = current_user.nickname
+    = link_to "/mypages/show" do
+      %label.currentusername
+        %i.far.fa-user
+        = current_user.nickname
     = link_to new_post_path do
       %label.post
         ー
         %i.fas.fa-pen-nib
         投稿する
-    %label.watch
-      ー
-      %i.fas.fa-film
-      過去の投稿
+    = link_to "/mypages" do
+      %label.watch
+        ー
+        %i.fas.fa-film
+        過去の投稿
     %label.log-out
       ー
       %i.fas.fa-sign-out-alt

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root "posts#index"
   resources :posts, only: [:index, :new, :show]
+  resources :mypages, only: [:index, :show]
 end


### PR DESCRIPTION
# What
・ログイン後トップページからユーザーマイページ・過去の投稿一覧へ飛べるようにする
・マイページにユーザー情報を表示する・編集ボタンからユーザー情報を編集できるページに飛べるようにする

# Why
・ログイン前にはボタンが表示されず、ログイン後にボタンを表示させ移動できるようにする
・マイページでユーザー情報を表示し、変更もできるようにするため